### PR TITLE
v 0.1 -- 과거 대화 display, database

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,8 @@
-import os
-import time
 import typing
 import openai
 import streamlit as st
+
+from chat import chat
 
 openai.api_key = st.secrets["OPENAI_API_KEY"]
 engine = st.secrets.GPT_MODEL
@@ -13,79 +13,17 @@ st.sidebar.header("Tell me about yourself")
 st.sidebar.subheader("Language")
 language = st.sidebar.radio(
     "Choose a language to learn",
+    key="language",
     options=["English", "Korean", "German"],
 )
-
 st.sidebar.subheader("Proficiency")
 proficiency = st.sidebar.radio(
-    f"Your {language} proficiency level",
+    f"CHoose yours {st.session_state.language} proficiency level",
+    key="proficiency",
     options=["Beginner", "Intermediate", "Advanced"],
 )
-st.write(f"the default is {language} w/ {proficiency}")
-
-def input_prmpt(messages: typing.List[dict]) -> str:
-    completion = openai.ChatCompletion.create(
-        model=engine,
-        messages=messages,
-    )
-    return completion.choices[0].message.content
-
-
-# Define a function to prompt the user for input and generate a response
-def chat():
-    messages: typing.List[dict] = [
-        {
-            "role": "system",
-            "content": f"Let's play role-play. Remember that I'm a Korean learning {language} and you are a fluent {language} speaker.\
-            My proficieny of {language} is {proficiency}. Let's say you work at a coffee shop and I am a client.",
-        },
-        {"role": "user", "content": "Hi"},
-    ]
-
-    turns = 0
-    prompt = st.text_input(label="You: ", key=turns)
-    st.write(f"You: {prompt}")
-    turns = 0
-    while len(prompt) > 0 and prompt != "quit":
-        if turns == 7:
-            break
-        turns += 1
-        messages.append(
-            {
-                "role": "user",
-                "content": prompt,
-            }
-        )
-        response = input_prmpt(messages)
-        st.write("Bot: ", response)
-        messages.append(
-            {
-                "role": "assistant",
-                "content": response,
-            }
-        )
-
-        prompt = st.text_input(label="You: ", key=turns)
-        st.write(f"You: {prompt}")
-        time.sleep(0.58)
-
-        # if st.button(label="End Conversation", on_click=True, key=turns*12345):
-        #     break
-
-    if prompt != "":
-        correction = correct(messages)
-        st.write(f"Bot: Here is my advice for you.\n{correction}")
-
-
-def correct(messages):
-    correction_request = {
-        "role": "assistant",
-        "content": "Could you give me feedback about my English in Korean?",
-    }
-    messages.append(correction_request)
-    response = input_prmpt(messages)
-    return response
-
-
-# Run the chatbot with a specific model
-chat()
+st.write(f"We're talking in {st.session_state.language} at the level of {st.session_state.proficiency}.")
+if "dialogue" not in st.session_state:
+    st.session_state.dialogue = ""
+st.write(st.session_state.dialogue)
+st.text_input(r"👇", key="utterance", on_change=chat)

--- a/chat.py
+++ b/chat.py
@@ -1,0 +1,69 @@
+import typing
+import pickle
+import openai
+import streamlit as st
+
+engine = st.secrets.GPT_MODEL
+# if "language" in st.session_state and "proficiency" in st.session_state:
+#     messages: typing.List[dict] = [
+#         {
+#             "role": "system",
+#             "content": f"Let's play role-play. Remember that I'm a Korean learning {st.session_state.language} and you are a fluent {st.session_state.language} speaker.\
+#             My proficieny of {st.session_state.language} is {st.session_state.proficiency}. Let's say you work at a coffee shop and I am a client.",
+#         },
+#         {"role": "user", "content": "Hi"},
+# ]
+
+# Define a function to prompt the user for input and generate a response
+
+def get_response(messages):
+    completion = openai.ChatCompletion.create(
+        model=engine,
+        messages=messages,
+    )
+    response = completion.choices[0].message.content
+    newitem = {
+        "role":"assistant",
+        "content":response, 
+    }
+    messages.append(newitem)
+
+    with open("history.pickle", "wb") as f:
+        pickle.dump(messages, f)
+
+def chat():
+    with open("history.pickle", "rb") as f:
+        messages = pickle.load(f)
+
+    messages.append({
+        "role": "user",
+        "content": st.session_state.utterance,
+    })
+    get_response(messages)
+    build_dialogue()
+
+
+def correct(messages:typing.List[dict]):
+    correction_request = {
+        "role": "assistant",
+        "content": "Could you give me feedback about my English in Korean?",
+    }
+    messages.append(correction_request)
+    response = get_response(messages)
+    return response
+
+def build_dialogue():
+    dialogue = []
+    with open("history.pickle", "rb") as f:
+        messages = pickle.load(f)
+
+    for turn in messages:
+        role, content = turn["role"], turn["content"]
+        if role == "system":
+            # do not display initial prompt setting
+            continue
+        elif role == "assistant": # different bot names for different situations
+            role = "bot" 
+        dialogue.append(f"{role}: {content}")
+    
+    st.session_state.dialogue = "\n\n".join(dialogue)


### PR DESCRIPTION
## 주요 변경점
* **database화**: openAPI로 request를 보내고 response를 받았을 때마다 pickle로 저장
답변을 "append"가 아니라 이전 대화도 다 "write" 해야 함. streamlit 기동 방식이 on_click에 해당되는 function 작동 후 이후 코드를 반복해서 top-down으로 실행하기 때문에 이전 runtime에서 변수에 저장해 놓은 데이터가 새로 인풋이 들어올 때마다 없어짐. 
* 기본 인터페이스 정리
1. 사이드: 레벨, 외국어 인풋 받기
2. 인풋 정리

## To-do
1. mongoDB 등 외부 DB에 저장
2. 유저가 선택한 외국어, 레벨에 따라 initial prompt가 들어있는 pickle 파일을 로드