### PR TITLE
v 0.2: 페이지 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__/
 
 # secrets
 /.streamlit/secrets.toml
+
+# pickle files and metadata files
+*.pickle
+last_seen_query.txt

--- a/app.py
+++ b/app.py
@@ -17,9 +17,15 @@ language = st.sidebar.radio(
     key="language",
     options=["English", "Korean", "German"],
 )
+st.sidebar.subheader("Situation")
+situation = st.sidebar.radio(
+    "Whare are you now?",
+    key="situation",
+    options=["Starbucks", "Movie theater", "McDonald's", "Subway", "Zara", "Bar"]
+)
 st.sidebar.subheader("Proficiency")
 proficiency = st.sidebar.radio(
-    f"Choose yours {st.session_state.language} proficiency level",
+    f"Choose your {st.session_state.language} proficiency level",
     key="proficiency",
     options=["Beginner", "Intermediate", "Advanced"],
 )
@@ -28,6 +34,7 @@ st.write(
 )
 if (
     "language" in st.session_state
+    and "situation" in st.session_state
     and "proficiency" in st.session_state
     and "logfile" not in st.session_state
 ):  # ❗️TO-DO: file name w/ user unique ID
@@ -36,7 +43,8 @@ if (
         setting_prompt: typing.List[dict] = [
             {
                 "role": "system",
-                "content": f"Let's play role-play. Remember that I'm a Korean learning {st.session_state.language} and you are a fluent {st.session_state.language} speaker. My proficieny of {st.session_state.language} is {st.session_state.proficiency}. Let's say you work at a coffee shop and I am a client.",
+                "content": f"Let's play role-play. Remember that I'm a Korean learning {st.session_state.language} and you are a fluent {st.session_state.language} speaker.\
+                My proficieny of {st.session_state.language} is {st.session_state.proficiency}. Let's say you work at a {st.session_state.situation} shop and I am a client.",
             },
         ]
         pickle.dump(setting_prompt, f)

--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ language = st.sidebar.radio(
 )
 st.sidebar.subheader("Proficiency")
 proficiency = st.sidebar.radio(
-    f"CHoose yours {st.session_state.language} proficiency level",
+    f"Choose yours {st.session_state.language} proficiency level",
     key="proficiency",
     options=["Beginner", "Intermediate", "Advanced"],
 )

--- a/app.py
+++ b/app.py
@@ -24,7 +24,13 @@ with st.form("setting"):
     situation = st.radio(
         "Whare are you now?",
         key="situation",
-        options=["Starbucks", "AMC(movie theater)", "McDonald's", "Subway(restaurant)", "Zara"]
+        options=[
+            "Starbucks",
+            "AMC(movie theater)",
+            "McDonald's",
+            "Subway(restaurant)",
+            "Zara",
+        ],
     )
     st.subheader("Proficiency")
     proficiency = st.radio(
@@ -55,9 +61,7 @@ if submitted:
     # log.append(setting_prompt)
     # save_history("log.pickle", log)
 
-    if (
-        "logfile" not in st.session_state
-    ):  # ❗️TO-DO: file name w/ user unique ID
+    if "logfile" not in st.session_state:  # ❗️TO-DO: file name w/ user unique ID
         st.session_state.logfile = "log.pickle"
         with open(st.session_state.logfile, "wb") as f:
             setting_prompt: typing.List[dict] = [
@@ -73,7 +77,7 @@ if submitted:
                 },
             ]
             pickle.dump(setting_prompt, f)
-        
+
     switch_page("interface")
 
 # if "dialogue" not in st.session_state:

--- a/app.py
+++ b/app.py
@@ -2,57 +2,65 @@ import typing
 import pickle
 import openai
 import streamlit as st
+from streamlit_extras.switch_page_button import switch_page
+from st_pages import hide_pages
 
-from chat import chat
+# from chat import chat
 
 openai.api_key = st.secrets["OPENAI_API_KEY"]
-engine = st.secrets.GPT_MODEL
+hide_pages(["interface"])
 
 st.title("Talk 2 Me")
+st.header("Tell me about yourself")
+with st.form("setting"):
+    st.subheader("Language")
+    language = st.radio(
+        "Choose a language to learn",
+        key="language",
+        options=["English", "Korean", "German"],
+    )
+    st.subheader("Situation")
+    situation = st.radio(
+        "Whare are you now?",
+        key="situation",
+        options=["Starbucks", "AMC(movie theater)", "McDonald's", "Subway(restaurant)", "Zara"]
+    )
+    st.subheader("Proficiency")
+    proficiency = st.radio(
+        f"Choose your {st.session_state.language} proficiency level",
+        key="proficiency",
+        options=["Beginner", "Intermediate", "Advanced"],
+    )
+    # st.write(
+    #     f"We're in {st.session_state.situation}. Let's talk in {st.session_state.language} at the {st.session_state.proficiency} level."
+    # )
+    submitted = st.form_submit_button("Let's talk!")
 
-st.sidebar.header("Tell me about yourself")
-st.sidebar.subheader("Language")
-language = st.sidebar.radio(
-    "Choose a language to learn",
-    key="language",
-    options=["English", "Korean", "German"],
-)
-st.sidebar.subheader("Situation")
-situation = st.sidebar.radio(
-    "Whare are you now?",
-    key="situation",
-    options=["Starbucks", "Movie theater", "McDonald's", "Subway", "Zara", "Bar"]
-)
-st.sidebar.subheader("Proficiency")
-proficiency = st.sidebar.radio(
-    f"Choose your {st.session_state.language} proficiency level",
-    key="proficiency",
-    options=["Beginner", "Intermediate", "Advanced"],
-)
-st.write(
-    f"We're talking in {st.session_state.language} at the level of {st.session_state.proficiency}."
-)
-if (
-    "language" in st.session_state
-    and "situation" in st.session_state
-    and "proficiency" in st.session_state
-    and "logfile" not in st.session_state
-):  # ❗️TO-DO: file name w/ user unique ID
-    st.session_state.logfile = "history.pickle"
-    with open(st.session_state.logfile, "wb") as f:
-        setting_prompt: typing.List[dict] = [
-            {
-                "role": "system",
-                "content": f"Let's play role-play. Remember that I'm a Korean learning {st.session_state.language} and you are a fluent {st.session_state.language} speaker.\
-                My proficieny of {st.session_state.language} is {st.session_state.proficiency}. Let's say you work at a {st.session_state.situation} shop and I am a client.",
-            },
-        ]
-        pickle.dump(setting_prompt, f)
+if submitted:
+    if (
+        "logfile" not in st.session_state
+    ):  # ❗️TO-DO: file name w/ user unique ID
+        st.session_state.logfile = "pages.pickle"
+        with open(st.session_state.logfile, "wb") as f:
+            setting_prompt: typing.List[dict] = [
+                {
+                    "language": st.session_state.language,
+                    "situation": st.session_state.situation,
+                    "proficiency": st.session_state.proficiency,
+                },
+                {
+                    "role": "system",
+                    "content": f"Let's play role-play. Remember that I'm a Korean learning {st.session_state.language} and you are a fluent {st.session_state.language} speaker.\
+                    My proficieny of {st.session_state.language} is {st.session_state.proficiency}. Let's say you work at {st.session_state.situation} and I am a client.",
+                },
+            ]
+            pickle.dump(setting_prompt, f)
+    switch_page("interface")
 
-if "dialogue" not in st.session_state:
-    st.session_state.dialogue = ""
-st.write(st.session_state.dialogue)
-st.text_input(r"👇", key="utterance", on_change=chat)
-st.button("Quit", key="end_conversation", on_click=chat)
-if "feedback" in st.session_state:
-    st.write(st.session_state.feedback)
+# if "dialogue" not in st.session_state:
+#     st.session_state.dialogue = ""
+# st.write(st.session_state.dialogue)
+# st.text_input(r"👇", key="utterance", on_change=chat)
+# st.button("Quit", key="end_conversation", on_click=chat)
+# if "feedback" in st.session_state:
+#     st.write(st.session_state.feedback)

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import typing
 import pickle
 import openai
 import streamlit as st
+from util.utils import *
 from streamlit_extras.switch_page_button import switch_page
 from st_pages import hide_pages
 
@@ -37,10 +38,27 @@ with st.form("setting"):
     submitted = st.form_submit_button("Let's talk!")
 
 if submitted:
+    # setting_prompt: typing.List[dict] = [
+    #             {
+    #                 "role": "system",
+    #                 "content": f"Let's play role-play. Remember that I'm a Korean learning {st.session_state.language} and you are a fluent {st.session_state.language} speaker.\
+    #                 My proficieny of {st.session_state.language} is {st.session_state.proficiency}. Let's say you work at {st.session_state.situation} and I am a client.",
+    #             },
+    #         ]
+
+    # log = load_history("log.pickle")
+    # log.append({
+    #     "language": st.session_state.language,
+    #     "situation": st.session_state.situation,
+    #     "proficiency": st.session_state.proficiency,
+    # })
+    # log.append(setting_prompt)
+    # save_history("log.pickle", log)
+
     if (
         "logfile" not in st.session_state
     ):  # ❗️TO-DO: file name w/ user unique ID
-        st.session_state.logfile = "pages.pickle"
+        st.session_state.logfile = "log.pickle"
         with open(st.session_state.logfile, "wb") as f:
             setting_prompt: typing.List[dict] = [
                 {
@@ -55,6 +73,7 @@ if submitted:
                 },
             ]
             pickle.dump(setting_prompt, f)
+        
     switch_page("interface")
 
 # if "dialogue" not in st.session_state:

--- a/app.py
+++ b/app.py
@@ -38,9 +38,6 @@ with st.form("setting"):
         key="proficiency",
         options=["Beginner", "Intermediate", "Advanced"],
     )
-    # st.write(
-    #     f"We're in {st.session_state.situation}. Let's talk in {st.session_state.language} at the {st.session_state.proficiency} level."
-    # )
     submitted = st.form_submit_button("Let's talk!")
 
 if submitted:
@@ -79,11 +76,3 @@ if submitted:
             pickle.dump(setting_prompt, f)
 
     switch_page("interface")
-
-# if "dialogue" not in st.session_state:
-#     st.session_state.dialogue = ""
-# st.write(st.session_state.dialogue)
-# st.text_input(r"👇", key="utterance", on_change=chat)
-# st.button("Quit", key="end_conversation", on_click=chat)
-# if "feedback" in st.session_state:
-#     st.write(st.session_state.feedback)

--- a/chat.py
+++ b/chat.py
@@ -21,7 +21,7 @@ def chat():
         )
         st.session_state.utterance = ""
         get_response(messages)
-        build_dialogue()
+        show_dialogue()
 
 
 def get_response(messages):
@@ -51,7 +51,7 @@ def get_feedback():
     get_response(messages)
 
 
-def build_dialogue():
+def show_dialogue():
     dialogue = []
     with open(st.session_state.logfile, "rb") as f:
         messages = pickle.load(f)
@@ -71,20 +71,8 @@ def build_dialogue():
 
 
 def show_feedback():
-    messages = load_history(st.session_state.logfile)
-    # with open(st.session_state.logfile, "rb") as f:
-    #     messages = pickle.load(f)
+    with open(st.session_state.logfile, "rb") as f:
+        messages = pickle.load(f)
 
     st.session_state.feedback = messages[-1]["content"]
-
-
-def load_history(filename):
-    with open(filename, "rb") as f:
-        history = pickle.load(f)
-
-    return history
-
-
-def save_history(filename, history):
-    with open(filename, "wb") as f:
-        pickle.dump(history, f)
+ 

--- a/chat.py
+++ b/chat.py
@@ -4,8 +4,6 @@ import openai
 import streamlit as st
 
 engine = st.secrets.GPT_MODEL
-# Define a function to prompt the user for input and generate a response
-
 
 def chat():
     with open(st.session_state.logfile, "rb") as f:
@@ -29,7 +27,7 @@ def chat():
 def get_response(messages):
     completion = openai.ChatCompletion.create(
         model=engine,
-        messages=messages,
+        messages=messages[1:],
     )
     response = completion.choices[0].message.content
     newitem = {
@@ -73,7 +71,20 @@ def build_dialogue():
 
 
 def show_feedback():
-    with open(st.session_state.logfile, "rb") as f:
-        messages = pickle.load(f)
+    messages = load_history(st.session_state.logfile)
+    # with open(st.session_state.logfile, "rb") as f:
+    #     messages = pickle.load(f)
 
     st.session_state.feedback = messages[-1]["content"]
+
+
+def load_history(filename):
+    with open(filename, "rb") as f:
+        history = pickle.load(f)
+
+    return history
+
+
+def save_history(filename, history):
+    with open(filename, "wb") as f:
+        pickle.dump(history, f)

--- a/pages/interface.py
+++ b/pages/interface.py
@@ -1,0 +1,12 @@
+import streamlit as st
+from chat import chat
+st.write(
+    f"We're in {st.session_state['situation']}. Let's talk in {st.session_state.language} at the {st.session_state.proficiency} level."
+)
+if "dialogue" not in st.session_state:
+    st.session_state.dialogue = ""
+st.write(st.session_state.dialogue)
+st.text_input(r"👇", key="utterance", on_change=chat)
+st.button("Quit", key="end_conversation", on_click=chat)
+if "feedback" in st.session_state:
+    st.write(st.session_state.feedback)

--- a/pages/interface.py
+++ b/pages/interface.py
@@ -4,7 +4,11 @@ from util.utils import *
 
 st.session_state.logfile = "log.pickle"
 log = load_history(st.session_state.logfile)
-st.session_state.situation, st.session_state.language, st.session_state.proficiency = log[0]["situation"], log[0]["language"], log[0]["proficiency"]
+st.session_state.situation, st.session_state.language, st.session_state.proficiency = (
+    log[0]["situation"],
+    log[0]["language"],
+    log[0]["proficiency"],
+)
 
 st.write(
     f"We're in {st.session_state.situation}. Let's talk in {st.session_state.language} at the {st.session_state.proficiency} level."

--- a/pages/interface.py
+++ b/pages/interface.py
@@ -1,8 +1,13 @@
 import streamlit as st
 from util.chat import chat
+from util.utils import *
+
+st.session_state.logfile = "log.pickle"
+log = load_history(st.session_state.logfile)
+st.session_state.situation, st.session_state.language, st.session_state.proficiency = log[0]["situation"], log[0]["language"], log[0]["proficiency"]
 
 st.write(
-    f"We're in {st.session_state['situation']}. Let's talk in {st.session_state.language} at the {st.session_state.proficiency} level."
+    f"We're in {st.session_state.situation}. Let's talk in {st.session_state.language} at the {st.session_state.proficiency} level."
 )
 if "dialogue" not in st.session_state:
     st.session_state.dialogue = ""

--- a/pages/interface.py
+++ b/pages/interface.py
@@ -1,5 +1,6 @@
 import streamlit as st
-from chat import chat
+from util.chat import chat
+
 st.write(
     f"We're in {st.session_state['situation']}. Let's talk in {st.session_state.language} at the {st.session_state.proficiency} level."
 )

--- a/util/chat.py
+++ b/util/chat.py
@@ -5,6 +5,7 @@ import streamlit as st
 
 engine = st.secrets.GPT_MODEL
 
+
 def chat():
     with open(st.session_state.logfile, "rb") as f:
         messages = pickle.load(f)
@@ -75,4 +76,3 @@ def show_feedback():
         messages = pickle.load(f)
 
     st.session_state.feedback = messages[-1]["content"]
- 

--- a/util/chat.py
+++ b/util/chat.py
@@ -3,6 +3,8 @@ import pickle
 import openai
 import streamlit as st
 
+from util.utils import *
+
 engine = st.secrets.GPT_MODEL
 
 
@@ -46,7 +48,7 @@ def get_feedback():
         messages = pickle.load(f)
     feedback_request = {
         "role": "assistant",
-        "content": f"Given the past dialogue, could you give me feedback in Korean about the user's {st.session_state.language} considering my {st.session_state.language} proficiency is {st.session_state.proficiency}? Correct me in details if i was wrong.",
+        "content": f"Given the past dialogue, could you give feedback in Korean about the user's (not assistant's) {st.session_state.language} considering his {st.session_state.language} proficiency is {st.session_state.proficiency}? Correct user's mistake in details if there is any.",
     }
     messages.append(feedback_request)
     get_response(messages)
@@ -57,7 +59,7 @@ def show_dialogue():
     with open(st.session_state.logfile, "rb") as f:
         messages = pickle.load(f)
 
-    for turn in messages:
+    for turn in messages[1:]:
         role, content = turn["role"], turn["content"]
         if role == "system":
             # do not display initial prompt setting

--- a/util/utils.py
+++ b/util/utils.py
@@ -1,6 +1,12 @@
 import pickle
+from pathlib import Path
 
 def load_history(filename):
+    p = Path(filename)
+    if not p.exists():
+        p.mkdir(parents=True)
+        return []
+
     with open(filename, "rb") as f:
         history = pickle.load(f)
 

--- a/util/utils.py
+++ b/util/utils.py
@@ -1,6 +1,7 @@
 import pickle
 from pathlib import Path
 
+
 def load_history(filename):
     p = Path(filename)
     if not p.exists():
@@ -16,6 +17,7 @@ def load_history(filename):
 def save_history(filename, history):
     with open(filename, "wb") as f:
         pickle.dump(history, f)
+
 
 # def get_new_queries():
 #     import datetime

--- a/util/utils.py
+++ b/util/utils.py
@@ -1,0 +1,18 @@
+import pickle
+
+def load_history(filename):
+    with open(filename, "rb") as f:
+        history = pickle.load(f)
+
+    return history
+
+
+def save_history(filename, history):
+    with open(filename, "wb") as f:
+        pickle.dump(history, f)
+
+# def get_new_queries():
+#     import datetime
+#     with open("last_seen_query.txt", "r") as f:
+#         last_date_time = f.readline().strip()
+#     logs = load_history("log.pickle")


### PR DESCRIPTION
## 변경점
* 세팅: 사이드바 제거 -> 초기 페이지(index/app)에서 언어/상황 등을 선택하고 새로운 페이지(interface)로 연결하여 대화.
* 로그파일에 과거 대화뿐만 아니라 초기 세팅값(언어, 상황, 능숙도)도 저장: interface.py 에서 chat.py를 호출할 때마다 app.py에서 지정되었던 session_state값들을 잊기 때문에 로그에 따로 저장해야 함 (별도 페이지화의 단점)
* 새로운 구조: pages/ + util/ 추가

## To-do
* 외부 DB에 연결
* 유저와 IP에 따라 user_input에 날짜를 담은 unique ID 배정 + is_replied 설정. 트리구조로 유저별 history 관리 필 